### PR TITLE
Support php 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.1', '8.2', '8.3', '8.4']
 
     services:
       mysql:

--- a/facturascripts.ini
+++ b/facturascripts.ini
@@ -2,4 +2,4 @@ name = 'CommandPalette'
 description = 'Paleta de comandos para navegación rápida con Ctrl+K / Cmd+K'
 version = 1
 min_version = 2025
-min_php = 8.2
+min_php = 8.1


### PR DESCRIPTION
This pull request makes small compatibility updates to support PHP 8.1 across the project. The minimum PHP version requirement is lowered, and the CI pipeline is updated to test against PHP 8.1.

* Compatibility updates:
  * Lowered the minimum required PHP version from 8.2 to 8.1 in `facturascripts.ini`.
  * Added PHP 8.1 to the CI matrix in `.github/workflows/ci.yml` to ensure automated testing against this version.